### PR TITLE
chore(release): pulling release/2.1.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## [2.1.0](https://github.com/rudderlabs/rudder-integration-facebook-ios/compare/v2.0.0...v2.1.0) (2023-04-27)
+
+
+### Features
+
+* upgrade dependency to 16.0.1 ([cc9d73e](https://github.com/rudderlabs/rudder-integration-facebook-ios/commit/cc9d73ea647ef561c68300426cb47a4ec520e7ed))

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,6 +1,6 @@
 use_frameworks!
 
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 target 'Rudder-Facebook_Example' do
   pod 'Rudder-Facebook', :path => '../'

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -37,7 +37,7 @@ SPEC CHECKSUMS:
   FBSDKCoreKit_Basics: d37280da2e65872f0e931d15f45d97ea324fec37
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   Rudder: 1353907b7323389ad213f3ef0a30969261f67773
-  Rudder-Facebook: 1b5ef71336dbd3f561bd2d0fa82eb44d254ae6a7
+  Rudder-Facebook: 06e922676d1616c26dc3fc9eaed019c3f514df5e
 
 PODFILE CHECKSUM: 7bc5675f1c4b3d6df991eedd0fb3fdaaac414a26
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
-  - FBAEMKit (13.2.0):
-    - FBSDKCoreKit_Basics (= 13.2.0)
-  - FBSDKCoreKit (13.2.0):
-    - FBAEMKit (= 13.2.0)
-    - FBSDKCoreKit_Basics (= 13.2.0)
-  - FBSDKCoreKit_Basics (13.2.0)
+  - FBAEMKit (16.0.1):
+    - FBSDKCoreKit_Basics (= 16.0.1)
+  - FBSDKCoreKit (16.0.1):
+    - FBAEMKit (= 16.0.1)
+    - FBSDKCoreKit_Basics (= 16.0.1)
+  - FBSDKCoreKit_Basics (16.0.1)
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - Rudder (1.6.0)
+  - Rudder (1.13.2)
   - Rudder-Facebook (2.0.0):
-    - FBSDKCoreKit (~> 13.2.0)
+    - FBSDKCoreKit (~> 16.0.1)
     - Rudder (~> 1.0)
 
 DEPENDENCIES:
@@ -32,13 +32,13 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FBAEMKit: c2b2895363b7e57192013d1dc49fdf498b28624c
-  FBSDKCoreKit: 58139803d861e72c7661dc875611a759352a55ac
-  FBSDKCoreKit_Basics: 1ffc68326a5ece051d85574f02a0adcf27c2a5f2
+  FBAEMKit: daac7466b918752f020345be5c7d9787f98cfc07
+  FBSDKCoreKit: 2cb033464b2134af0138f87d20b859eb3f9be359
+  FBSDKCoreKit_Basics: d37280da2e65872f0e931d15f45d97ea324fec37
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  Rudder: 67c3dffe0b253236794e448d5d279a4d54819804
-  Rudder-Facebook: da04216dec5c1907619abe2062651551bdba6e7e
+  Rudder: 1353907b7323389ad213f3ef0a30969261f67773
+  Rudder-Facebook: 1b5ef71336dbd3f561bd2d0fa82eb44d254ae6a7
 
-PODFILE CHECKSUM: 046968ef657e641218309baa81ef9eb5d96cf12a
+PODFILE CHECKSUM: 7bc5675f1c4b3d6df991eedd0fb3fdaaac414a26
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/Rudder-Facebook.podspec
+++ b/Rudder-Facebook.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     s.license          = { :type => "Apache", :file => "LICENSE" }
     s.author           = { 'Rudderlabs' => 'arnab@rudderlabs.com' }
     s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-facebook-ios.git', :tag => "v#{s.version}" }
-    s.platform         = :ios, "11.0"
+    s.platform         = :ios, "12.0"
 
     s.source_files = 'Rudder-Facebook/Classes/**/*'
 

--- a/Rudder-Facebook.podspec
+++ b/Rudder-Facebook.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
     s.source_files = 'Rudder-Facebook/Classes/**/*'
 
     s.dependency 'Rudder', '~> 1.0'
-    s.dependency 'FBSDKCoreKit', '~> 13.2.0'
+    s.dependency 'FBSDKCoreKit', '~> 16.0.1'
 end

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2023-04-27)<br> * chore: update branch name in draft-new-release.yml ( 17) ([d535727](https://github.com/rudderlabs/rudder-integration-facebook-ios/commit/d535727)), closes [ 17](https://github.com/rudderlabs/rudder-integration-facebook-ios/issues/17)<br> * chore: update pod spec ([66f21f8](https://github.com/rudderlabs/rudder-integration-facebook-ios/commit/66f21f8))<br> * feat: upgrade dependency to 16.0.1 ([cc9d73e](https://github.com/rudderlabs/rudder-integration-facebook-ios/commit/cc9d73e))<br> * ci: add ci/cd action to detect outdated pods ([7d796d3](https://github.com/rudderlabs/rudder-integration-facebook-ios/commit/7d796d3))<br> * ci: added CI/CD pipeline ([093bfc8](https://github.com/rudderlabs/rudder-integration-facebook-ios/commit/093bfc8))<br> * ci: fix publish-new-release ([c7c1e13](https://github.com/rudderlabs/rudder-integration-facebook-ios/commit/c7c1e13))