### PR TITLE
feat: update Facebook sdk to latest v17.0.0

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,19 +1,25 @@
 PODS:
-  - FBAEMKit (16.0.1):
-    - FBSDKCoreKit_Basics (= 16.0.1)
-  - FBSDKCoreKit (16.0.1):
-    - FBAEMKit (= 16.0.1)
-    - FBSDKCoreKit_Basics (= 16.0.1)
-  - FBSDKCoreKit_Basics (16.0.1)
+  - FBAEMKit (17.0.2):
+    - FBSDKCoreKit_Basics (= 17.0.2)
+  - FBSDKCoreKit (17.0.2):
+    - FBAEMKit (= 17.0.2)
+    - FBSDKCoreKit_Basics (= 17.0.2)
+  - FBSDKCoreKit_Basics (17.0.2)
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - Rudder (1.14.0)
+  - MetricsReporter (1.2.1):
+    - RSCrashReporter (= 1.0.1)
+    - RudderKit (= 1.4.0)
+  - RSCrashReporter (1.0.1)
+  - Rudder (1.27.0):
+    - MetricsReporter (= 1.2.1)
   - Rudder-Facebook (2.1.0):
-    - FBSDKCoreKit (~> 16.0.1)
+    - FBSDKCoreKit (~> 17.0.2)
     - Rudder (~> 1.12)
+  - RudderKit (1.4.0)
 
 DEPENDENCIES:
   - FBSnapshotTestCase
@@ -25,20 +31,26 @@ SPEC REPOS:
     - FBSDKCoreKit
     - FBSDKCoreKit_Basics
     - FBSnapshotTestCase
+    - MetricsReporter
+    - RSCrashReporter
     - Rudder
+    - RudderKit
 
 EXTERNAL SOURCES:
   Rudder-Facebook:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FBAEMKit: daac7466b918752f020345be5c7d9787f98cfc07
-  FBSDKCoreKit: 2cb033464b2134af0138f87d20b859eb3f9be359
-  FBSDKCoreKit_Basics: d37280da2e65872f0e931d15f45d97ea324fec37
+  FBAEMKit: 619f96ea65427e8afca240d5b0f4703738dfdf5c
+  FBSDKCoreKit: a5f384db2e9ee84e98494fed8f983d2bd79accff
+  FBSDKCoreKit_Basics: d35c775aaf243a2d731dfae7be3a74b1987285ab
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  Rudder: 41523d90e7f8040605ca6a803f662a538144c90f
-  Rudder-Facebook: 0f1d705d7d35a2ea9fe50a279972c2c41bb9bd52
+  MetricsReporter: 99596ee5003c69949ed2f50acc34aee83c42f843
+  RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
+  Rudder: 3cfcd9e6c5359cd6d49f411101ed9b894e3b64bd
+  Rudder-Facebook: a16ee7b2052a92a19865a31698ab77a6a1706c04
+  RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
 
 PODFILE CHECKSUM: 7bc5675f1c4b3d6df991eedd0fb3fdaaac414a26
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.15.2

--- a/Example/Rudder-Facebook.xcodeproj/project.pbxproj
+++ b/Example/Rudder-Facebook.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 				ORGANIZATIONNAME = arnab;
 				TargetAttributes = {
 					6003F589195388D20070C39A = {
-						DevelopmentTeam = GTGKNDBD23;
+						DevelopmentTeam = UCL2K3J73M;
 						LastSwiftMigration = 1430;
 					};
 					6003F5AD195388D20070C39A = {
@@ -354,16 +354,22 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Rudder-Facebook_Example/Pods-Rudder-Facebook_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/MetricsReporter/MetricsReporter.framework",
+				"${BUILT_PRODUCTS_DIR}/RSCrashReporter/RSCrashReporter.framework",
 				"${BUILT_PRODUCTS_DIR}/Rudder/Rudder.framework",
 				"${BUILT_PRODUCTS_DIR}/Rudder-Facebook/Rudder_Facebook.framework",
+				"${BUILT_PRODUCTS_DIR}/RudderKit/RudderKit.framework",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/FBAEMKit/FBAEMKit.framework/FBAEMKit",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/FBSDKCoreKit/FBSDKCoreKit.framework/FBSDKCoreKit",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/FBSDKCoreKit_Basics/FBSDKCoreKit_Basics.framework/FBSDKCoreKit_Basics",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MetricsReporter.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RSCrashReporter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Rudder.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Rudder_Facebook.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RudderKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBAEMKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKCoreKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKCoreKit_Basics.framework",
@@ -506,7 +512,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -539,7 +545,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -552,12 +558,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = GTGKNDBD23;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Rudder-Facebook/Rudder-Facebook-Prefix.pch";
 				INFOPLIST_FILE = "Rudder-Facebook/Rudder-Facebook-Info.plist";
 				MODULE_NAME = ExampleApp;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.demo.rudderfacebook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rudder-Facebook/Rudder-Facebook_Example-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -572,12 +578,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = GTGKNDBD23;
+				DEVELOPMENT_TEAM = UCL2K3J73M;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Rudder-Facebook/Rudder-Facebook-Prefix.pch";
 				INFOPLIST_FILE = "Rudder-Facebook/Rudder-Facebook-Info.plist";
 				MODULE_NAME = ExampleApp;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.demo.rudderfacebook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Rudder-Facebook/Rudder-Facebook_Example-Bridging-Header.h";
 				SWIFT_VERSION = 4.0;

--- a/Example/Rudder-Facebook/Rudder-Facebook-Info.plist
+++ b/Example/Rudder-Facebook/Rudder-Facebook-Info.plist
@@ -20,10 +20,29 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>fbAppID</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>FacebookAppID</key>
+	<string>AppID</string>
+	<key>FacebookClientToken</key>
+	<string>Client Token</string>
+	<key>FacebookDisplayName</key>
+	<string>Display Name</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Select allow to send event to Facebook App Events</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -45,22 +64,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>fbAPPID</string>
-			</array>
-		</dict>
-	</array>
-	<key>FacebookAppID</key>
-	<string>APPID</string>
-	<key>FacebookClientToken</key>
-	<string>CLIENTOKEN</string>
-	<key>FacebookDisplayName</key>
-	<string>DISPLAYNAME</string>
-	<key>NSUserTrackingUsageDescription</key>
-	<string>Select allow to send event to Facebook App Events</string>
 </dict>
 </plist>

--- a/Example/Rudder-Facebook/SampleRudderConfig.plist
+++ b/Example/Rudder-Facebook/SampleRudderConfig.plist
@@ -3,18 +3,18 @@
 <plist version="1.0">
 <dict>
 	<key>WRITE_KEY</key>
-	<string>35PI7HEmgbRe1R0lEYqeh3</string>
+	<string></string>
 	<key>PROD_DATA_PLANE_URL</key>
-	<string>https://rudderstac.dataplane.rudderstack.com</string>
+	<string></string>
 	<key>PROD_CONTROL_PLANE_URL</key>
-	<string>https://api.rudderlabs.com</string>
+	<string></string>
 	<key>LOCAL_DATA_PLANE_URL</key>
-	<string>https://521b-2405-201-8000-614f-54d9-9a90-4bbb-8143.in.ngrok.io</string>
+	<string></string>
 	<key>LOCAL_CONTROL_PLANE_URL</key>
-	<string>https://c7a9-2405-201-8000-614f-54d9-9a90-4bbb-8143.in.ngrok.io</string>
+	<string></string>
 	<key>DEV_DATA_PLANE_URL</key>
-	<string>https://bec3-2405-201-8000-614f-54d9-9a90-4bbb-8143.in.ngrok.io</string>
+	<string></string>
 	<key>DEV_CONTROL_PLANE_URL</key>
-	<string>https://9a50-2405-201-8000-614f-54d9-9a90-4bbb-8143.in.ngrok.io</string>
+	<string></string>
 </dict>
 </plist>

--- a/Rudder-Facebook.podspec
+++ b/Rudder-Facebook.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-facebook_sdk_version = '~> 16.0.1'
+facebook_sdk_version = '~> 17.0.2'
 rudder_sdk_version = '~> 1.12'
 deployment_target = '12.0'
 facebook_app_events = 'FBSDKCoreKit'


### PR DESCRIPTION
1 . facebook SDK version is updated to latest version 17.0.2 . there is no change in behaviour as per the testing on fb console for event tracking.
2 . As per the requirements mentioned , privacy report is able to generate for facebook corekit.