### PR TITLE
fix: support Facebook SDK 18 and fix $FacebookSDKVersion override

### DIFF
--- a/Rudder-Facebook.podspec
+++ b/Rudder-Facebook.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-facebook_sdk_version = '~> 17.0.2'
+facebook_sdk_version = ['>= 17.0.2', '< 19.0']
 rudder_sdk_version = '~> 1.12'
 deployment_target = '12.0'
 facebook_app_events = 'FBSDKCoreKit'
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     
     if defined?($FacebookSDKVersion)
       facebook_sdk_version = $FacebookSDKVersion
-      Pod::UI.puts "#{s.name}: Using user specified Facebook SDK version '#{FacebookSDKVersion}'"
+      Pod::UI.puts "#{s.name}: Using user specified Facebook SDK version '#{$FacebookSDKVersion}'"
     else
       Pod::UI.puts "#{s.name}: Using default facebook SDK version '#{facebook_sdk_version}'"
     end
@@ -40,5 +40,5 @@ Pod::Spec.new do |s|
     end
     
     s.dependency 'Rudder', rudder_sdk_version
-    s.dependency facebook_app_events, facebook_sdk_version
+    s.dependency facebook_app_events, *Array(facebook_sdk_version)
 end


### PR DESCRIPTION
Two small fixes to the `FBSDKCoreKit` dependency.

**1) Allow FBSDK 18.**
The pod is pinned to `~> 17.0.2`, so apps on FBSDK 18 can't install it — `pod install` fails with a version clash. Widen the default to `>= 17.0.2, < 19.0`. Same App Events APIs in both; builds on 18.

**2) Fix the `$FacebookSDKVersion` hook.**
It crashes: the log line uses `#{FacebookSDKVersion}` (missing the `$`), so `pod install` dies with `uninitialized constant Pod::FacebookSDKVersion`.

Repro for #2:
```ruby
$FacebookSDKVersion = '~> 18.0'
# → [!] uninitialized constant Pod::FacebookSDKVersion
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
