### PR TITLE
fix: support Facebook SDK 18 and fix $FacebookSDKVersion override

### DIFF
--- a/Rudder-Facebook.podspec
+++ b/Rudder-Facebook.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
       facebook_sdk_version = $FacebookSDKVersion
       Pod::UI.puts "#{s.name}: Using user specified Facebook SDK version '#{$FacebookSDKVersion}'"
     else
-      Pod::UI.puts "#{s.name}: Using default facebook SDK version '#{facebook_sdk_version}'"
+      Pod::UI.puts "#{s.name}: Using default facebook SDK version '#{Array(facebook_sdk_version).join(', ')}'"
     end
 
     if defined?($RudderSDKVersion)

--- a/Rudder-Facebook.podspec
+++ b/Rudder-Facebook.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-facebook_sdk_version = '~> 17.0.2'
+facebook_sdk_version = ['>= 17.0.2', '< 19.0']
 rudder_sdk_version = '~> 1.12'
 deployment_target = '12.0'
 facebook_app_events = 'FBSDKCoreKit'
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     
     if defined?($FacebookSDKVersion)
       facebook_sdk_version = $FacebookSDKVersion
-      Pod::UI.puts "#{s.name}: Using user specified Facebook SDK version '#{FacebookSDKVersion}'"
+      Pod::UI.puts "#{s.name}: Using user specified Facebook SDK version '#{$FacebookSDKVersion}'"
     else
       Pod::UI.puts "#{s.name}: Using default facebook SDK version '#{facebook_sdk_version}'"
     end
@@ -40,5 +40,5 @@ Pod::Spec.new do |s|
     end
     
     s.dependency 'Rudder', rudder_sdk_version
-    s.dependency facebook_app_events, facebook_sdk_version
+    s.dependency facebook_app_events, *Array(facebook_sdk_version)
 end

--- a/Rudder-Facebook.podspec
+++ b/Rudder-Facebook.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
     s.source_files = 'Rudder-Facebook/Classes/**/*'
     s.ios.deployment_target = deployment_target
     
-    if defined?($FacebookSDKVersion)
+    if defined?($FacebookSDKVersion) && !$FacebookSDKVersion.to_s.empty?
       facebook_sdk_version = $FacebookSDKVersion
       Pod::UI.puts "#{s.name}: Using user specified Facebook SDK version '#{$FacebookSDKVersion}'"
     else


### PR DESCRIPTION
## Description

Updates the `FBSDKCoreKit` dependency handling in `Rudder-Facebook.podspec` to support Facebook SDK 18.x and to fix a crash in the `$FacebookSDKVersion` override path.

Previously the pod pinned the Facebook SDK to `~> 17.0.2`, which only allows `17.0.x`. Apps that use Facebook SDK 18.x could not install the pod because of a version conflict. Additionally, setting the `$FacebookSDKVersion` global in a `Podfile` crashed `pod install` due to a missing `$` in a log statement.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details

- Widened the default Facebook SDK version constraint from `~> 17.0.2` to `['>= 17.0.2', '< 19.0']`, allowing all `17.x` and `18.x` releases.
- Fixed the `$FacebookSDKVersion` override log line: it referenced `#{FacebookSDKVersion}` (missing the `$`), which Ruby resolved as the undefined constant `Pod::FacebookSDKVersion` and crashed `pod install` with `uninitialized constant Pod::FacebookSDKVersion`. Now uses `#{$FacebookSDKVersion}`.
- Passed the version requirement to `s.dependency` via `*Array(facebook_sdk_version)`, so both a user-supplied string override and the default multi-requirement array are forwarded correctly.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?

Verified locally against the `Example` app:

1. **Facebook SDK 18 resolves** — `pod update FBSDKCoreKit` installs `FBSDKCoreKit 18.1.0` with the new range (previously blocked at `17.0.x`).
2. **Override no longer crashes** — set `$FacebookSDKVersion = '~> 17.0'` in the `Podfile` and run `pod install`; it prints `Using user specified Facebook SDK version` and installs successfully. On the previous podspec the same step crashed with `uninitialized constant Pod::FacebookSDKVersion`.
3. **Builds against FBSDK 18** — `xcodebuild` of the `Rudder-Facebook-Example` scheme against `FBSDKCoreKit 18.1.0` completes with `BUILD SUCCEEDED`; the integration only uses stable App Events APIs unchanged in 18.

## Breaking Changes

None. The change only widens the allowed dependency range and fixes the override path; existing installs on `17.x` are unaffected.

## Maintainers Checklist

- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)

N/A

## Additional Context

Reference implementation: original external contribution in rudderlabs/rudder-integration-facebook-ios#56. Tracked under Linear SDK-5068.
